### PR TITLE
feat: [HW-1] Add basic CLI for RSS

### DIFF
--- a/.idea/intellias-golang-bootcamp.iml
+++ b/.idea/intellias-golang-bootcamp.iml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
+  <component name="Go" enabled="true" />
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$" />

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: cli-build
+cli-build:
+	go build ./cmd/cli
+
+.PHOHY: cli-run
+cli-run:
+	go run ./cmd/cli

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # Intellias Golang Bootcamp [2025]
+
+
+## Commands
+
+### Build as CLI
+
+```shell
+make cli-build
+```
+
+### Run a CLI
+
+```shell
+make cli-run
+```

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"github.com/bshevchuk/intellias-golang-bootcamp/internal/downloader"
+	"github.com/bshevchuk/intellias-golang-bootcamp/internal/parser"
+	"os"
+)
+
+const defaultRssUrl = "https://dou.ua/feed/"
+
+func main() {
+
+	// Download content
+	content, err := downloader.Download(defaultRssUrl)
+	if err != nil {
+		fmt.Printf("exit with error: %v", err)
+		os.Exit(1)
+	}
+
+	// Parse as RSS
+	rss, err := parser.ParseRss(content)
+	if err != nil {
+		fmt.Printf("exit with error: %v", err)
+		os.Exit(1)
+	}
+
+	// Show RSS
+	fmt.Printf("%s\n", rss.Channel.Title)
+	for _, item := range rss.Channel.Items {
+		fmt.Printf("\t %s\n"+
+			"\t %s\n\n", item.Title, item.Link)
+	}
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -7,7 +7,8 @@ import (
 	"os"
 )
 
-const defaultRssUrl = "https://dou.ua/feed/"
+// const defaultRssUrl = "https://dou.ua/feed/"
+const defaultRssUrl = "https://news.ycombinator.com/rss"
 
 func main() {
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/bshevchuk/intellias-golang-bootcamp
+
+go 1.24.2

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -1,0 +1,26 @@
+package downloader
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func Download(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s returned HTTP status %s", url, resp.Status)
+	}
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,0 +1,13 @@
+package parser
+
+import "encoding/xml"
+
+func ParseRss(data []byte) (Rss, error) {
+	var rss Rss
+	err := xml.Unmarshal(data, &rss)
+	if err != nil {
+		return Rss{}, err
+	}
+
+	return rss, nil
+}

--- a/internal/parser/rss.go
+++ b/internal/parser/rss.go
@@ -1,0 +1,17 @@
+package parser
+
+type Rss struct {
+	Channel Channel `xml:"channel"`
+}
+
+type Channel struct {
+	Title string `xml:"title"`
+	Items []Item `xml:"item"`
+}
+
+type Item struct {
+	Title       string `xml:"title"`
+	Link        string `xml:"link"`
+	Description string `xml:"description"`
+	PubDate     string `xml:"pubDate"`
+}


### PR DESCRIPTION
# Homework 1

Small tool for download RSS feeds​

1. Application should take URL to RSS feed from variable​
2. Load content and parse it by using standard library​
3. Result should be retuned from function and printed in main function​
4. The main function and core functionality should be located in different packages

---

# Test

```
$ make cli-run                 
go run ./cmd/cli
Hacker News
         The last six months in LLMs, illustrated by pelicans on bicycles
         https://simonwillison.net/2025/Jun/6/six-months-in-llms/

         The Illusion of Thinking: Strengths and Limitations of Reasoning Models
         https://machinelearning.apple.com/research/illusion-of-thinking

         Binfmtc – binfmt_misc C scripting interface
         https://www.netfort.gr.jp/~dancer/software/binfmtc.html.en
```

```
$ make cli-run
go run ./cmd/cli
Найцікавіше на DOU
         Курси з основ Python зможуть безоплатно пройти ветерани та їхні сім’ї
         https://dou.ua/lenta/news/veterans-can-study-python/

         В Sigma Software зміниться СЕО: хто очолить компанію
         https://dou.ua/lenta/news/sigma-software-group-changes-management/
```


